### PR TITLE
fix: make loadtest deployment random labels deterministic

### DIFF
--- a/extloadtest/discovery_kubernetes_deployment.go
+++ b/extloadtest/discovery_kubernetes_deployment.go
@@ -2,7 +2,6 @@ package extloadtest
 
 import (
 	"fmt"
-	"math/rand"
 
 	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
 	"github.com/steadybit/discovery-kit/go/discovery_kit_commons"
@@ -50,8 +49,8 @@ func createKubernetesDeploymentTargets(nodeCount int, suffix string) []discovery
 			"k8s.deployment.label.run":                        {"loadtest"},
 			"k8s.deployment.label.service-tier":               {"2"},
 			"k8s.deployment.label.index":                      {fmt.Sprintf("%d", i)},
-			"k8s.deployment.label.random-number":              {fmt.Sprintf("random-%d", 1+rand.Intn(5))},
-			"k8s.deployment.label.random-char":                {fmt.Sprintf("random-%s", []string{"a", "b", "c", "d", "e"}[rand.Intn(5)])},
+			"k8s.deployment.label.random-number":              {fmt.Sprintf("random-%d", 1+i%5)},
+			"k8s.deployment.label.random-char":                {fmt.Sprintf("random-%s", []string{"a", "b", "c", "d", "e"}[i%5])},
 			"k8s.deployment.label.tags.datadoghq.com/service": {"shop-products"},
 			"k8s.deployment.label.tags.datadoghq.com/version": {"1.0.0"},
 			"k8s.distribution":                                {"kubernetes"},


### PR DESCRIPTION
The `random-char`/`random-number` deployment labels rolled fresh `rand` values on every discovery cycle, so all ~5500 synthetic loadtest deployments were reported as changed every minute — driving continuous target rediscovery + cross-enrichment churn (and cascading container/pod rewrites) that saturated the dev demo RDS (90-97% CPU, ~260k deployment UPDATEs/2h). Now seeded from the deployment index so values are stable across discoveries while preserving label cardinality.

Pairs with agent PR lowering the `no-copy-rule` update rate 100x.

(ticket: TODO)