### PR TITLE
fix: synchronize discovery reads with config updates and recreate actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix: synchronize discovery reads with the `/config/*` updates and the recreate actions so concurrent requests no longer race on the configuration and target data
+- fix: make the recreate actions actually bump the target id (the previous in-place update was discarded, so recreate was a silent no-op)
+
 ## v1.0.10
 
 - Support discovery group attribute via `STEADYBIT_EXTENSION_DISCOVERY_GROUP` env var (or `discovery.group` Helm value) — when set, the extension adds `steadybit.group=<value>` to every discovered target

--- a/config/config.go
+++ b/config/config.go
@@ -10,10 +10,18 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rs/zerolog/log"
 	"strings"
+	"sync"
 )
 
 var (
 	Config Specification
+
+	// Mu guards the runtime-mutable Config fields (AttributeUpdates,
+	// TargetReplacements, SimulateExtensionRestarts) against the data race between
+	// the /config/* update handlers writing them and the discoveries reading them.
+	// Readers take RLock via the Find* accessors; the update handlers take Lock
+	// while unmarshalling the request body into Config.
+	Mu sync.RWMutex
 )
 
 const (
@@ -222,6 +230,8 @@ func ValidateConfiguration() {
 }
 
 func (s *Specification) FindAttributeUpdate(t string) *AttributeUpdateSpecification {
+	Mu.RLock()
+	defer Mu.RUnlock()
 	for _, update := range s.AttributeUpdates {
 		if update.Type == t {
 			return &update
@@ -231,6 +241,8 @@ func (s *Specification) FindAttributeUpdate(t string) *AttributeUpdateSpecificat
 }
 
 func (s *Specification) FindTargetReplacementsSpecification(t string) *TargetReplacementsSpecification {
+	Mu.RLock()
+	defer Mu.RUnlock()
 	for _, replacement := range s.TargetReplacements {
 		if replacement.Type == t {
 			return &replacement
@@ -240,6 +252,8 @@ func (s *Specification) FindTargetReplacementsSpecification(t string) *TargetRep
 }
 
 func (s *Specification) FindSimulateExtensionRestartSpecification(t string) *SimulateExtensionRestartSpecification {
+	Mu.RLock()
+	defer Mu.RUnlock()
 	for _, restart := range s.SimulateExtensionRestarts {
 		if restart.Type == t {
 			return &restart

--- a/config/config.go
+++ b/config/config.go
@@ -229,6 +229,11 @@ func ValidateConfiguration() {
 	}
 }
 
+// FindAttributeUpdate returns the matching spec or nil. It returns a pointer to
+// the range-loop copy (heap-allocated via escape analysis), never &s.AttributeUpdates[i],
+// so callers may safely dereference it after RUnlock has fired. Any new accessor
+// must keep this property — returning a slice-element pointer would let callers
+// race a concurrent write through Mu. The Find* accessors below follow the same rule.
 func (s *Specification) FindAttributeUpdate(t string) *AttributeUpdateSpecification {
 	Mu.RLock()
 	defer Mu.RUnlock()

--- a/extloadtest/discovery.go
+++ b/extloadtest/discovery.go
@@ -13,13 +13,19 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-kit/exthttp"
-	"github.com/steadybit/extension-kit/extutil"
 	"github.com/steadybit/extension-loadtest/config"
 	"net/http"
+	"sync"
 	"time"
 )
 
 type TargetData struct {
+	// mu guards the target/enrichment-data slices below against the data race
+	// between the recreate actions replacing them and the discoveries reading them.
+	// Recreate takes Lock and replaces slices wholesale (copy-on-write); the
+	// discoveries read through the targetSnapshot/enrichmentDataSnapshot closures,
+	// which take RLock and return the current slice header.
+	mu                    sync.RWMutex
 	hosts                 []discovery_kit_api.Target
 	ec2Instances          []discovery_kit_api.Target
 	azureInstances        []discovery_kit_api.Target
@@ -131,7 +137,7 @@ func NewTargetData() *TargetData {
 }
 
 type ltTargetDiscovery struct {
-	targets     *[]discovery_kit_api.Target
+	snapshot    func() []discovery_kit_api.Target
 	description func() discovery_kit_api.DiscoveryDescription
 }
 
@@ -154,7 +160,9 @@ func (l ltTargetDiscovery) DiscoverTargets(ctx context.Context) ([]discovery_kit
 
 	attrSpec := config.Config.FindAttributeUpdate(typeId)
 	replSpec := config.Config.FindTargetReplacementsSpecification(typeId)
-	total := len(*l.targets)
+
+	targets := l.snapshot()
+	total := len(targets)
 
 	host := ""
 	if config.Config.ServicesEnabled {
@@ -171,12 +179,12 @@ func (l ltTargetDiscovery) DiscoverTargets(ctx context.Context) ([]discovery_kit
 	// per-request allocation) memory profile.
 	hasAttr := attrSpec != nil && attrSpec.Rate > attributeUpdateDisableThreshold
 	if host == "" && !hasAttr && replSpec == nil {
-		return *l.targets, nil
+		return targets, nil
 	}
 
 	result := make([]discovery_kit_api.Target, 0, total)
-	for i := range *l.targets {
-		base := &(*l.targets)[i]
+	for i := range targets {
+		base := &targets[i]
 		if isTargetReplaced(base.Id, total, replSpec, now) {
 			continue
 		}
@@ -238,7 +246,7 @@ func prefixAttribute(target *discovery_kit_api.Target, attributeName string, pre
 }
 
 type ltEdDiscovery struct {
-	data        *[]discovery_kit_api.EnrichmentData
+	snapshot    func() []discovery_kit_api.EnrichmentData
 	description func() discovery_kit_api.DiscoveryDescription
 }
 
@@ -257,17 +265,19 @@ func (l ltEdDiscovery) DiscoverEnrichmentData(_ context.Context) ([]discovery_ki
 
 	attrSpec := config.Config.FindAttributeUpdate(typeId)
 	replSpec := config.Config.FindTargetReplacementsSpecification(typeId)
-	total := len(*l.data)
+
+	data := l.snapshot()
+	total := len(data)
 
 	// Zero-copy fast path (see DiscoverTargets): nothing to mutate, serve the shared slice.
 	hasAttr := attrSpec != nil && attrSpec.Rate > attributeUpdateDisableThreshold
 	if !hasAttr && replSpec == nil {
-		return *l.data, nil
+		return data, nil
 	}
 
 	result := make([]discovery_kit_api.EnrichmentData, 0, total)
-	for i := range *l.data {
-		base := &(*l.data)[i]
+	for i := range data {
+		base := &data[i]
 		if isTargetReplaced(base.Id, total, replSpec, now) {
 			continue
 		}
@@ -287,28 +297,46 @@ func (l ltEdDiscovery) DiscoverEnrichmentData(_ context.Context) ([]discovery_ki
 	return result, nil
 }
 
+// targetSnapshot returns a reader that serves the current slice under RLock, so
+// the recreate actions can replace the slice without racing the discoveries.
+func (t *TargetData) targetSnapshot(targets *[]discovery_kit_api.Target) func() []discovery_kit_api.Target {
+	return func() []discovery_kit_api.Target {
+		t.mu.RLock()
+		defer t.mu.RUnlock()
+		return *targets
+	}
+}
+
+func (t *TargetData) enrichmentDataSnapshot(data *[]discovery_kit_api.EnrichmentData) func() []discovery_kit_api.EnrichmentData {
+	return func() []discovery_kit_api.EnrichmentData {
+		t.mu.RLock()
+		defer t.mu.RUnlock()
+		return *data
+	}
+}
+
 func (t *TargetData) RegisterDiscoveries() {
 	if !config.Config.DisableHostDiscovery {
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryHost, targets: &t.hosts})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryHost, snapshot: t.targetSnapshot(&t.hosts)})
 	}
 	if !config.Config.DisableAWSDiscovery {
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryEc2Instance, targets: &t.ec2Instances})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryEc2Instance, snapshot: t.targetSnapshot(&t.ec2Instances)})
 	}
 	if !config.Config.DisableGCPDiscovery {
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryGcpInstance, targets: &t.gcpInstances})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryGcpInstance, snapshot: t.targetSnapshot(&t.gcpInstances)})
 	}
 	if !config.Config.DisableAzureDiscovery {
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryAzureInstance, targets: &t.azureInstances})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryAzureInstance, snapshot: t.targetSnapshot(&t.azureInstances)})
 	}
 	if !config.Config.DisableKubernetesDiscovery {
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesCluster, targets: &t.kubernetesClusters})
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesDeployment, targets: &t.kubernetesDeployments})
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesPods, targets: &t.kubernetesPods})
-		discovery_kit_sdk.Register(&ltEdDiscovery{description: getDiscoveryKubernetesContainer, data: &t.kubernetesContainers})
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesNode, targets: &t.kubernetesNodes})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesCluster, snapshot: t.targetSnapshot(&t.kubernetesClusters)})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesDeployment, snapshot: t.targetSnapshot(&t.kubernetesDeployments)})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesPods, snapshot: t.targetSnapshot(&t.kubernetesPods)})
+		discovery_kit_sdk.Register(&ltEdDiscovery{description: getDiscoveryKubernetesContainer, snapshot: t.enrichmentDataSnapshot(&t.kubernetesContainers)})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryKubernetesNode, snapshot: t.targetSnapshot(&t.kubernetesNodes)})
 	}
 	if !config.Config.DisableContainerDiscovery {
-		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryContainer, targets: &t.containers})
+		discovery_kit_sdk.Register(&ltTargetDiscovery{description: getDiscoveryContainer, snapshot: t.targetSnapshot(&t.containers)})
 	}
 }
 
@@ -321,7 +349,9 @@ func (t *TargetData) RegisterRecreateActions() {
 			Query:       "host.hostname=\"\"",
 		},
 		func(name string) {
-			updateTargetId(t.hosts, name, "com.steadybit.extension_host.host")
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			t.hosts = updateTargetId(t.hosts, name, "com.steadybit.extension_host.host")
 			t.ec2Instances = createEc2InstanceTargets(t.hosts)
 			t.kubernetesPods = createKubernetesPodTargets(t.hosts, t.kubernetesDeployments)
 			t.kubernetesContainers = createKubernetesContainerTargets(t.kubernetesPods)
@@ -338,7 +368,9 @@ func (t *TargetData) RegisterRecreateActions() {
 			Query:       "k8s.cluster-name=\"\" and k8s.namespace=\"\" and k8s.deployment=\"\"",
 		},
 		func(name string) {
-			updateEnrichmentDataId(t.kubernetesContainers, name, "com.steadybit.extension_kubernetes.kubernetes-container")
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			t.kubernetesContainers = updateEnrichmentDataId(t.kubernetesContainers, name, "com.steadybit.extension_kubernetes.kubernetes-container")
 			t.containers = createContainerTargets(t.kubernetesContainers)
 		},
 	))
@@ -349,21 +381,32 @@ func (t *TargetData) RegisterConfigUpdateHandlers() {
 	exthttp.RegisterHttpHandler("/config/attributeUpdates", t.updateConfigHandler(&config.Config.AttributeUpdates))
 }
 
-func (t *TargetData) updateConfigHandler(config any) exthttp.Handler {
+func (t *TargetData) updateConfigHandler(configField any) exthttp.Handler {
 	return func(w http.ResponseWriter, r *http.Request, body []byte) {
-		if r.Method == http.MethodPost {
-			clone := extutil.JsonMangle(config)
-			err := json.Unmarshal(body, clone)
+		switch r.Method {
+		case http.MethodPost:
+			// Unmarshal into the live config field (configField is a pointer into
+			// config.Config) under the write lock so the update both takes effect and
+			// is serialized against the discoveries reading it via the Find* accessors.
+			// The lock is released before writing the response so a slow client cannot
+			// stall the discoveries; the echo below re-reads under RLock.
+			config.Mu.Lock()
+			err := json.Unmarshal(body, configField)
+			if err == nil {
+				t.rescheduleUpdates()
+			}
+			config.Mu.Unlock()
 			if err != nil {
 				w.WriteHeader(400)
 				_, _ = w.Write([]byte(err.Error()))
+				return
 			}
-			config = clone
-			t.rescheduleUpdates()
-			exthttp.WriteBody(w, config)
-		} else if r.Method == http.MethodGet {
-			exthttp.WriteBody(w, config)
-		} else {
+			fallthrough
+		case http.MethodGet:
+			config.Mu.RLock()
+			defer config.Mu.RUnlock()
+			exthttp.WriteBody(w, configField)
+		default:
 			w.WriteHeader(405)
 		}
 	}

--- a/extloadtest/discovery.go
+++ b/extloadtest/discovery.go
@@ -388,12 +388,15 @@ func (t *TargetData) updateConfigHandler(configField any) exthttp.Handler {
 			// Unmarshal into the live config field (configField is a pointer into
 			// config.Config) under the write lock so the update both takes effect and
 			// is serialized against the discoveries reading it via the Find* accessors.
-			// The lock is released before writing the response so a slow client cannot
-			// stall the discoveries; the echo below re-reads under RLock.
+			// Marshal the echo while still holding the lock so it reflects exactly what
+			// was just written, then release before the socket write so a slow client
+			// cannot stall the discoveries.
 			config.Mu.Lock()
 			err := json.Unmarshal(body, configField)
+			var responseBody []byte
 			if err == nil {
 				t.rescheduleUpdates()
+				responseBody, err = json.Marshal(configField)
 			}
 			config.Mu.Unlock()
 			if err != nil {
@@ -401,7 +404,8 @@ func (t *TargetData) updateConfigHandler(configField any) exthttp.Handler {
 				_, _ = w.Write([]byte(err.Error()))
 				return
 			}
-			fallthrough
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(responseBody)
 		case http.MethodGet:
 			config.Mu.RLock()
 			defer config.Mu.RUnlock()

--- a/extloadtest/discovery.go
+++ b/extloadtest/discovery.go
@@ -383,18 +383,18 @@ func (t *TargetData) RegisterConfigUpdateHandlers() {
 
 func (t *TargetData) updateConfigHandler(configField any) exthttp.Handler {
 	return func(w http.ResponseWriter, r *http.Request, body []byte) {
+		// Both methods marshal the response while holding the config lock so it
+		// reflects exactly the serialized state, then release before the socket write
+		// so a slow client cannot stall the discoveries (a pending writer would
+		// otherwise block their Find* RLock calls for the duration of the write).
+		var responseBody []byte
+		var err error
 		switch r.Method {
 		case http.MethodPost:
-			// Unmarshal into the live config field (configField is a pointer into
-			// config.Config) under the write lock so the update both takes effect and
-			// is serialized against the discoveries reading it via the Find* accessors.
-			// Marshal the echo while still holding the lock so it reflects exactly what
-			// was just written, then release before the socket write so a slow client
-			// cannot stall the discoveries.
+			// configField is a pointer into config.Config; unmarshal under the write
+			// lock so the update takes effect and is serialized against the discoveries.
 			config.Mu.Lock()
-			err := json.Unmarshal(body, configField)
-			var responseBody []byte
-			if err == nil {
+			if err = json.Unmarshal(body, configField); err == nil {
 				t.rescheduleUpdates()
 				responseBody, err = json.Marshal(configField)
 			}
@@ -404,15 +404,21 @@ func (t *TargetData) updateConfigHandler(configField any) exthttp.Handler {
 				_, _ = w.Write([]byte(err.Error()))
 				return
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write(responseBody)
 		case http.MethodGet:
 			config.Mu.RLock()
-			defer config.Mu.RUnlock()
-			exthttp.WriteBody(w, configField)
+			responseBody, err = json.Marshal(configField)
+			config.Mu.RUnlock()
+			if err != nil {
+				w.WriteHeader(500)
+				_, _ = w.Write([]byte(err.Error()))
+				return
+			}
 		default:
 			w.WriteHeader(405)
+			return
 		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(responseBody)
 	}
 }
 

--- a/extloadtest/utils.go
+++ b/extloadtest/utils.go
@@ -5,6 +5,7 @@ package extloadtest
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -12,47 +13,55 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
 )
 
-func updateTargetId(targets []discovery_kit_api.Target, name, targetType string) {
-	updateId(targets, name, targetType, func(i discovery_kit_api.Target) string {
+func updateTargetId(targets []discovery_kit_api.Target, name, targetType string) []discovery_kit_api.Target {
+	return updateId(targets, name, targetType, func(i discovery_kit_api.Target) string {
 		return i.Id
 	}, func(i *discovery_kit_api.Target, v string) {
 		i.Id = v
 	})
 }
 
-func updateEnrichmentDataId(dataList []discovery_kit_api.EnrichmentData, name, targetType string) {
-	updateId(dataList, name, targetType, func(i discovery_kit_api.EnrichmentData) string {
+func updateEnrichmentDataId(dataList []discovery_kit_api.EnrichmentData, name, targetType string) []discovery_kit_api.EnrichmentData {
+	return updateId(dataList, name, targetType, func(i discovery_kit_api.EnrichmentData) string {
 		return i.Id
 	}, func(i *discovery_kit_api.EnrichmentData, v string) {
 		i.Id = v
 	})
 }
 
-func updateId[T any](targets []T, name, targetType string, getter func(i T) string, setter func(i *T, v string)) {
-	for _, target := range targets {
-		id := getter(target)
+// updateId returns a copy of targets with the element matching name bumped to the
+// next @version. A fresh slice is returned (copy-on-write) so concurrent readers
+// holding the previous slice are never mutated under them. The previous in-place
+// variant ranged over value copies and discarded the write, so recreate was a no-op.
+func updateId[T any](targets []T, name, targetType string, getter func(i T) string, setter func(i *T, v string)) []T {
+	updated := slices.Clone(targets)
 
-		if id == name {
-			version := 0
-			idWithoutVersion := id
-			if versionSeparator := strings.LastIndex(id, "@"); versionSeparator != -1 {
-				version, _ = strconv.Atoi(id[versionSeparator+1:])
-				idWithoutVersion = id[:versionSeparator]
-			}
-			newId := fmt.Sprintf("%s@%d", idWithoutVersion, version+1)
-			setter(&target, newId)
-
-			log.Info().
-				Str("type", targetType).
-				Str("newId", newId).
-				Str("id", id).
-				Msg("recreated target")
-			return
+	for i := range updated {
+		id := getter(updated[i])
+		if id != name {
+			continue
 		}
+
+		version := 0
+		idWithoutVersion := id
+		if versionSeparator := strings.LastIndex(id, "@"); versionSeparator != -1 {
+			version, _ = strconv.Atoi(id[versionSeparator+1:])
+			idWithoutVersion = id[:versionSeparator]
+		}
+		newId := fmt.Sprintf("%s@%d", idWithoutVersion, version+1)
+		setter(&updated[i], newId)
+
+		log.Info().
+			Str("type", targetType).
+			Str("newId", newId).
+			Str("id", id).
+			Msg("recreated target")
+		return updated
 	}
 
 	log.Warn().
 		Str("type", targetType).
 		Str("name", name).
 		Msg("missing target to recreate")
+	return updated
 }


### PR DESCRIPTION
## Problem

A re-audit of the load-test simulator found a data race between concurrent HTTP requests:

- The `/config/*` update handlers (`updateConfigHandler`) write `config.Config.AttributeUpdates` / `config.Config.TargetReplacements` while the discoveries read them via `FindAttributeUpdate` / `FindTargetReplacementsSpecification` / `FindSimulateExtensionRestartSpecification`.
- The recreate actions replace the `TargetData` slices (`ec2Instances`, `kubernetesPods`, …) while the discoveries read them via `*l.targets` / `*l.data`.

Both are unsynchronized concurrent map/slice-header accesses. The Go runtime can `fatal` on a concurrent map write (not recoverable by `exthttp.PanicRecovery`), and at minimum the discoveries could serve torn data.

While fixing this I also found that `updateConfigHandler`'s POST path unmarshalled into a throwaway `extutil.JsonMangle` clone and discarded it, so config updates never took effect — and `updateId` ranged over value copies, so the recreate actions never actually bumped the target id (a silent no-op).

## Fix

- **config**: add `config.Mu sync.RWMutex`. The three `Find*` accessors take `RLock`; the update handler takes `Lock` while unmarshalling into the live config field. The exclusive lock is released before the response is written (echo re-reads under `RLock`) so a slow client cannot stall the discoveries.
- **discovery**: add `TargetData.mu sync.RWMutex`. The discoveries read through `targetSnapshot` / `enrichmentDataSnapshot` closures that take `RLock` and return the current slice header; the recreate actions take `Lock` and replace the slices wholesale (copy-on-write). Encapsulating the lock in the snapshot closures means it cannot be forgotten when a new discovery is added. The zero-copy fast path for large target counts is preserved.
- **utils**: `updateId` is now copy-on-write — it returns a fresh slice with the matched element bumped, which the callbacks assign back. This both fixes the silent no-op and keeps readers holding a previous snapshot safe.

## Verification

- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass.
- `/simplify` (reuse / simplification / efficiency / altitude) run; applied: `slices.Clone`, snapshot-closure encapsulation of the lock, and narrowing the POST lock so only `RLock` is held across the response write.
