### PR TITLE
chore(deps): bump go to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.26.4'
+      go_version: '^1.26.5'
       build_linux_packages: true
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
     secrets:

--- a/extloadtest/deterministic.go
+++ b/extloadtest/deterministic.go
@@ -66,10 +66,7 @@ func deterministicAttributeValue(id string, spec *config.AttributeUpdateSpecific
 	cur := bucketIndex(now, spec.Interval)
 	period := int64(1)
 	if spec.Rate > 0 {
-		period = int64(math.Round(1.0 / spec.Rate))
-		if period < 1 {
-			period = 1
-		}
+		period = max(int64(math.Round(1.0/spec.Rate)), 1)
 	}
 	phase := int64(stableHash(id) % uint64(period))
 	lastChange := cur - positiveMod(cur-phase, period)

--- a/extloadtest/deterministic_test.go
+++ b/extloadtest/deterministic_test.go
@@ -45,7 +45,7 @@ func TestAttributeValueChangesAcrossBuckets(t *testing.T) {
 	spec := attrSpec(0.5, 600) // period 2
 	id := "x"
 	seen := map[string]bool{}
-	for b := int64(0); b < 12; b++ {
+	for b := range int64(12) {
 		seen[deterministicAttributeValue(id, spec, time.Unix(b*600+300, 0))] = true
 	}
 	require.Greater(t, len(seen), 1, "value must roll over across buckets")
@@ -57,7 +57,7 @@ func TestAttributeChangeRateMatchesConfiguredRate(t *testing.T) {
 	b0 := time.Unix(1000*600+300, 0)
 	b1 := time.Unix(1001*600+300, 0)
 	changed := 0
-	for i := 0; i < n; i++ {
+	for i := range n {
 		id := "id-" + strconv.Itoa(i)
 		if deterministicAttributeValue(id, spec, b0) != deterministicAttributeValue(id, spec, b1) {
 			changed++
@@ -84,7 +84,7 @@ func TestReplacementOmitsApproximatelyCountAndRotates(t *testing.T) {
 	b1 := time.Unix(3001*600+300, 0)
 
 	omitted, rotated := 0, false
-	for i := 0; i < total; i++ {
+	for i := range total {
 		id := "id-" + strconv.Itoa(i)
 		o0 := isTargetReplaced(id, total, spec, b0)
 		if o0 {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-loadtest
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
Bump Go to 1.26.5 in go.mod and CI. Also ran `go fix` and `go mod tidy`.